### PR TITLE
More fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+---
+
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: ruby:2.5.0
+
+    working_directory: /app
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - bundler-dependencies-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Install dependencies
+          command: bundle install
+
+      - save_cache:
+          key: bundler-dependencies-{{ checksum "Gemfile.lock" }}
+          paths:
+            - /usr/local/bundle
+
+      - run:
+          name: Run our checks
+          command: scripts/ci.sh

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # .rubocop remote config cache
 .rubocop-*-yml
+
+# sample module
+decidim-module-my_component

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,5 @@
 # rspec failure tracking
 .rspec_status
 
-# .rubocop remote config cache
-.rubocop-*-yml
-
 # sample module
 decidim-module-my_component

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.3
-before_install: gem install bundler -v 1.14.5

--- a/lib/decidim/generators/generators.rb
+++ b/lib/decidim/generators/generators.rb
@@ -28,16 +28,12 @@ module Decidim
         @engine_description = ask "Write a description for the new component:"
 
         template "templates/decidim-engine.gemspec.erb", "#{engine_folder}/decidim-#{engine_name}.gemspec"
-
         template "templates/Gemfile.erb", "#{engine_folder}/Gemfile" if options[:external]
-
         template "templates/Rakefile", "#{engine_folder}/Rakefile"
-
         template "templates/README.md.erb", "#{engine_folder}/README.md"
-
         template "templates/.rubocop.yml", "#{engine_folder}/.rubocop.yml"
-
         template "templates/.gitignore", "#{engine_folder}/.gitignore"
+        template "templates/.circleci/config.yml", "#{engine_folder}/.circleci/config.yml"
 
         app_folder = "#{engine_folder}/app"
         template "templates/app/assets/config/engine_manifest.css", "#{app_folder}/assets/config/decidim_#{engine_name}_manifest.css"

--- a/lib/decidim/generators/generators.rb
+++ b/lib/decidim/generators/generators.rb
@@ -48,7 +48,7 @@ module Decidim
         template "templates/app/helpers/decidim/engine/application_helper.rb.erb", "#{app_folder}/helpers/decidim/#{engine_name}/application_helper.rb"
         template "templates/app/models/decidim/engine/application_record.rb.erb", "#{app_folder}/models/decidim/#{engine_name}/application_record.rb"
         template "templates/app/models/decidim/engine/abilities/admin/admin_ability.rb.erb", "#{app_folder}/models/decidim/#{engine_name}/abilities/admin/admin_ability.rb"
-        template "templates/app/models/decidim/engine/abilities/current_user.rb.erb", "#{app_folder}/models/decidim/#{engine_name}/abilities/current_user.rb"
+        template "templates/app/models/decidim/engine/abilities/current_user_ability.rb.erb", "#{app_folder}/models/decidim/#{engine_name}/abilities/current_user_ability.rb"
 
         bin_folder = "#{engine_folder}/bin"
         template "templates/bin/rails.erb", "#{bin_folder}/rails"

--- a/lib/decidim/generators/templates/.circleci/config.yml
+++ b/lib/decidim/generators/templates/.circleci/config.yml
@@ -1,0 +1,47 @@
+---
+
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: decidim/decidim@sha256:348fb1faa49cfe76ba7cbeafc67ca09002cf95f0ffa7a76eefa9d5b3774e0ee9
+        environment:
+          DATABASE_USERNAME: postgres
+
+      - image: postgres
+        environment:
+          POSTGRES_USER: postgres
+
+    working_directory: /app
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - bundler-dependencies-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Install dependencies
+          command: bundle install
+
+      - save_cache:
+          key: bundler-dependencies-{{ checksum "Gemfile.lock" }}
+          paths:
+            - /usr/local/bundle
+
+      - run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+      - run:
+          name: Generate test app
+          command: bundle exec rake decidim:generate_external_test_app
+
+      - run:
+          name: Run RSpec tests
+          command: bundle exec rspec
+
+      - store_artifacts:
+          path: /app/spec/decidim_dummy_app/tmp/screenshots

--- a/lib/decidim/generators/templates/.gitignore
+++ b/lib/decidim/generators/templates/.gitignore
@@ -10,9 +10,6 @@
 # rspec failure tracking
 .rspec_status
 
-# .rubocop remote config cache
-.rubocop-*-yml
-
 # default test application
 spec/decidim_dummy_app
 

--- a/lib/decidim/generators/templates/.rubocop.yml
+++ b/lib/decidim/generators/templates/.rubocop.yml
@@ -1,3 +1,50 @@
 ---
 
-inherit_from: https://raw.githubusercontent.com/decidim/decidim/master/.rubocop.yml
+AllCops:
+  DisplayCopNames: true
+
+  DisplayStyleGuide: true
+
+  TargetRubyVersion: 2.3
+
+Metrics:
+  Enabled: false
+
+Rails:
+  Enabled: true
+
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+
+Lint/InterpolationCheck:
+  Enabled: false
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/TrivialAccessors:
+  ExactNameMatch: true
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
+Style/Lambda:
+  EnforcedStyle: literal
+
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
+Style/RaiseArgs:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/lib/decidim/generators/templates/Rakefile
+++ b/lib/decidim/generators/templates/Rakefile
@@ -1,3 +1,9 @@
 # frozen_string_literal: true
 
 require "decidim/dev/common_rake"
+
+desc "Generates a dummy app for testing"
+task test_app: "decidim:generate_external_test_app"
+
+desc "Generates a development app."
+task development_app: "decidim:generate_external_development_app"

--- a/lib/decidim/generators/templates/decidim-engine.gemspec.erb
+++ b/lib/decidim/generators/templates/decidim-engine.gemspec.erb
@@ -6,8 +6,8 @@ require "decidim/<%= engine_name %>/version"
 
 Gem::Specification.new do |s|
   s.version = Decidim::<%= engine_module_name %>.version
-  s.authors = ["Your Name"]
-  s.email = ["your_email@example.org"]
+  s.authors = ["<%= %x[git config user.name].chomp %>"]
+  s.email = ["<%= %x[git config user.email].chomp %>"]
   s.license = "AGPL-3.0"
   s.homepage = "https://github.com/decidim/decidim-module-<%= engine_name %>"
   s.required_ruby_version = ">= 2.3.1"

--- a/lib/decidim/generators/templates/decidim-engine.gemspec.erb
+++ b/lib/decidim/generators/templates/decidim-engine.gemspec.erb
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.summary = "A decidim <%= engine_name %> module"
   s.description = "<%= engine_description %>."
 
-  s.files = Dir["lib/**/*", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,lib}/**/*", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-core", Decidim::<%= engine_module_name %>.version
 end

--- a/lib/decidim/generators/templates/lib/decidim/engine/engine.rb.erb
+++ b/lib/decidim/generators/templates/lib/decidim/engine/engine.rb.erb
@@ -16,7 +16,7 @@ module Decidim
       end
 
       initializer "decidim_<%= engine_name %>.assets" do |app|
-        app.config.assets.precompile += %w(decidim_<%= engine_name %>_manifest.js decidim_<%= engine_name %>_manifest.css)
+        app.config.assets.precompile += %w[decidim_<%= engine_name %>_manifest.js decidim_<%= engine_name %>_manifest.css]
       end
 
       initializer "decidim_<%= engine_name %>.inject_abilities_to_user" do |_app|

--- a/lib/decidim/generators/templates/spec/spec_helper.rb.erb
+++ b/lib/decidim/generators/templates/spec/spec_helper.rb.erb
@@ -6,7 +6,7 @@ ENV["ENGINE_NAME"] = File.dirname(__dir__).split("/").last
 
 <%- if options[:external] -%>
 Decidim::Dev.dummy_app_path = File.expand_path(File.join("spec", "decidim_dummy_app"))
-<% else %>
+<%- else -%>
 Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_dummy_app"))
 <%- end -%>
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+echo "My Dummy Component" | bundle exec bin/decidim-generators engine my_component


### PR DESCRIPTION
Bug fixes:

* Gemspec was including too few files.
* One ability file name was incorrect.
* Codeclimate does not support remote rubocop configs. So I added a minimal rubocop config that is green on the generated application.

Features:
* Autofill gemspec information with git credentials.
* Add CircleCI config for decidim-generators itself.
* Add a sample CircleCI config for the generated module.
* Include shortcuts for dev app generations.